### PR TITLE
Bug fix auto transcription

### DIFF
--- a/config/sample.urls.json
+++ b/config/sample.urls.json
@@ -1,7 +1,7 @@
 {
     "spjall_url": "abcd",
     "tiro_url": "https://ritari.talgreinir.is/v1alpha1/transcriptjob:submit",
-    "transcripts_url": "https://ritari.talgreinir.is/v1alpha1/transcripts",
+    "transcripts_url": "https://ritari.talgreinir.is/v1alpha1/transcripts?pageSize=1000",
     "samromur_url": "https://s3bucketname.s3.eu-west-2.amazonaws.com",
     "test_audio": "https://s3bucketname.s3.eu-west-2.amazonaws.com/uu_id_client_a.wav",  
     "filter_transcripts_url": "https://ritari.talgreinir.is/v1alpha1/transcripts?filter=metadata.keywords%20CONTAINS%20",

--- a/uploading.py
+++ b/uploading.py
@@ -9,10 +9,18 @@ from extract import Extraction
 
 
 def post(extracted,spjall_response):
-    '''checks if the audio file is already on tiro. Creates body for the files and posts them to tiro.'''
+    '''
+    Checks if the audio file is already on tiro. Creates body for the files and
+    posts them to tiro.
+
+    Some recordings on spjall have audio that's too short, exclude those when
+    submitting to Tiro's editor because Tiro always shows them as
+    recordingDuration null even if it's actually 2 seconds long.
+    '''
     print('Posting files to tiro')
     submitted_file = open('files_submitted_to_tiro.log','w')
     spjall_convo_list = spjall_response.json()
+    min_duration = 60
     for convo in spjall_convo_list:
       is_a = False
       is_b = False
@@ -28,14 +36,14 @@ def post(extracted,spjall_response):
 
         authorization = {'Authorization': "Bearer {}".format(API_TOKEN)}
 
-        if not is_a:
+        if (not is_a and convo['client_a']['duration_seconds'] > min_duration):
           test_a = samromur_url + "/" + convo['session_id'] + "/"+convo['session_id'] + '_client_a.wav'
           subject_a = convo['session_id']+'_client_a.wav'
           body_a = create_body(subject_a,test_a)
           a_res = requests.post(urls['tiro_url'],data=json.dumps(body_a),headers=authorization)
           print(a_res.json(), file = submitted_file) 
 
-        if not is_b:
+        if (not is_b and convo['client_b']['duration_seconds'] > min_duration):
           test_b = samromur_url + "/" + convo['session_id'] + "/"+convo['session_id'] + '_client_b.wav'
           subject_b = convo['session_id']+'_client_b.wav'
           body_b = create_body(subject_b,test_b)


### PR DESCRIPTION
Previously when submitting files it would always resubmit the following two types of files for transcribing:
* files with duration under 1 min because they would show up in tiro's list as recordingDuration null
* files which had fallen off of the 100 most recent files

So the fixes are:
* Change tiro's transcripts list page size from default of 100 to 1000. We likely won't have as many as 1000 separate audio files.
* Never submit audio files which have a duration under 1 min anymore.
